### PR TITLE
Added support for loading environment vars from optional .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ logs
 .sass-cache
 node_modules
 .idea
+.env
 
 # Ignore generated build files
 build/mozaik.js

--- a/config.js
+++ b/config.js
@@ -1,3 +1,6 @@
+// Load environment variables from .env file if available
+require('dotenv').load();
+
 var config = {
     env:  'prod',
     host: 'localhost',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bluebird": "^2.4.2",
     "browserify": "^8.0.2",
     "d3": "^3.5.2",
+    "dotenv": "^0.5.1",
     "express": "^4.10.6",
     "font-awesome": "^4.2.0",
     "glob": "^4.3.2",


### PR DESCRIPTION
- Using dotenv to load `.env` file (from project root directory)
- File is optional and works nicely with `process.env`
- Example of `.env`:

        # See https://www.npmjs.com/package/dotenv for docs
        PORT=4000
        GITHUB_API_TOKEN=your-github-token