### PR TITLE
Added support for showing clock in different timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "memory-cache": "0.0.5",
     "moment": "^2.8.4",
     "moment-duration-format": "^1.3.0",
+    "moment-timezone": "^0.3.0",
     "react": "^0.12.2",
     "react-tools": "^0.12.2",
     "reactify": "^0.17.1",


### PR DESCRIPTION
- New optional config parameter: `timezone` where value can be any of the documented ones: http://momentjs.com/timezone/docs/ (example: `America/Toronto`)
- New dependency: moment-timezone
- Some errors are shown due to missing api, but it works
- Future development idea: Show sun/moon icon based on whether it is night or day

NOTE: I'll update the `mozaik-ext-time` once the extensibility branch starts to work.