### PR TITLE
Added default gulp task

### DIFF
--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,0 +1,3 @@
+var gulp   = require('gulp');
+
+gulp.task('default', ['publish']);


### PR DESCRIPTION
- Set default task to `publish` so users don't have guess/read gulpfile source
- Set as a file, thus available also in external widgets that are re-using the gulp tasks