### PR TITLE
Speedup the development by uglifying only for production

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,4 +1,7 @@
 module.exports = {
     src:  './src/',
-    dest: './build/'
+    dest: './build/',
+    isProduction: function(file) {
+        return process.env.NODE_ENV === 'production';
+    }
 };

--- a/gulp/tasks/jsmin.js
+++ b/gulp/tasks/jsmin.js
@@ -1,12 +1,13 @@
 var gulp   = require('gulp');
 var uglify = require('gulp-uglify');
+var gulpif = require('gulp-if');
 var _      = require('lodash');
 var rename = require('gulp-rename');
 var config = require('../config');
 
 gulp.task('js:min', ['react'], function () {
     return gulp.src(config.dest + '/mozaik.js')
-        .pipe(uglify())
+        .pipe(gulpif(config.isProduction, uglify()))
         .pipe(rename({suffix: '.min'}))
         .pipe(gulp.dest(config.dest))
     ;

--- a/gulp/tasks/react.js
+++ b/gulp/tasks/react.js
@@ -7,7 +7,7 @@ var config     = require('../config');
 
 gulp.task('react', ['collect:js'], function () {
     var bundler = browserify(config.src + 'App.jsx', {
-        debug: true
+        debug: !config.isProduction()
     });
 
     bundler.transform(reactify, {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-stylus": "^2.0.0",
     "gulp-uglify": "^1.0.2",
+    "gulp-if": "^1.2.5",
     "heroku-client": "^1.9.0",
     "jest-cli": "^0.2.1",
     "jquery": "^2.1.3",


### PR DESCRIPTION
Run uglify only if NODE_ENV==='production' as it takes about 12sec per change.
As a side note: React compilation seems surprisingly slow, too.