### PR TITLE
Enable .css inclusion with stylus

### DIFF
--- a/gulp/tasks/styl.js
+++ b/gulp/tasks/styl.js
@@ -9,6 +9,7 @@ gulp.task('styl', ['collect:styl'], function () {
     return gulp
         .src(config.src + 'core/styl/mozaik.styl')
         .pipe(stylus({
+            'include css': true,
             use: function (style) {
                 style.define('$theme', appConfig.theme);
             }


### PR DESCRIPTION
With `include css` option stylus can include .css into mozaik.css just like with .styl files.
This is needed for example when extension wants to include a 3rd party .css file with it