### PR TITLE
Fix the missing env variable

### DIFF
--- a/src/Mozaik.js
+++ b/src/Mozaik.js
@@ -10,6 +10,7 @@ class Mozaik {
         this.config = config;
 
         this.serverConfig = {
+            env:  config.env,
             host: config.host,
             port: config.port
         };


### PR DESCRIPTION
Provide `env` variable to the server so that it can server either `mozaik.js` or `mozaik.min.js`