### PR TITLE
Fixed config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Widgets are maintained as separate modules, thus available via [mozaik-ext-name 
   ```javascript
 
   module.exports = {
-    env: process.env.NODE_ENV || 'production',
+    env: process.env.MOZAIK_ENV || 'prod',
     host: 'localhost',
     port: process.env.PORT || 5000,
 


### PR DESCRIPTION
Match example config value with the template. Because code is not using the common node convention of 'development' and 'production', use custom `MOZAIK_ENV` instead.