### PR TITLE
Should only rotate dashboards when more than 1

### DIFF
--- a/src/browser/stores/DashboardStore.js
+++ b/src/browser/stores/DashboardStore.js
@@ -22,7 +22,7 @@ var DashboardStore = Reflux.createStore({
     },
 
     start() {
-        if (_config.rotationDuration && _dashboards.length > 0 && _timer === null) {
+        if (_config.rotationDuration && _dashboards.length > 1 && _timer === null) {
             _timer = setInterval(() => {
                 this.nextDashboard();
             }, _config.rotationDuration);


### PR DESCRIPTION
Currently, the dashboards rotate as long as there is one dashboard.
There is no need to rotate only 1 dashboard. which causes the whole Dashboard component to be redrawn