### PR TITLE
Allow user to define the express instance

### DIFF
--- a/src/Mozaik.js
+++ b/src/Mozaik.js
@@ -2,6 +2,7 @@ var winston = require('winston');
 var path    = require('path');
 var chalk   = require('chalk');
 var Bus     = require('./Bus');
+var express = require('express');
 
 class Mozaik {
     constructor(config) {
@@ -24,8 +25,13 @@ class Mozaik {
         this.bus = new Bus(this);
     }
 
-    startServer() {
-        require('./server')(this);
+    /**
+     * @param  {Express} app
+     */
+    startServer(app) {
+        app = app || express();
+
+        require('./server')(this, app);
     }
 
     /**

--- a/src/server.js
+++ b/src/server.js
@@ -6,12 +6,11 @@ var _       = require('lodash');
 
 /**
  * @param {Mozaik} mozaik
+ * @param {Express} app
  */
-module.exports = function (mozaik) {
+module.exports = function (mozaik, app) {
 
     var config = mozaik.serverConfig;
-
-    var app = express();
 
     mozaik.logger.info(chalk.yellow('serving static contents from ' + mozaik.baseDir + 'build'));
     app.use(express.static(mozaik.baseDir + '/build'));


### PR DESCRIPTION
Allows developers to add their own middleware to express. For example it allows adding authentication for the dashboard.