### PR TITLE
Access the 'env' from the correct config variable

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,7 @@ module.exports = function (mozaik) {
 
     app.get('/', function (req, res) {
         res.render('index', {
-            env:           config.env,
+            env:           mozaik.config.env,
             appTitle:      mozaik.config.appTitle,
             assetsBaseUrl: mozaik.config.assetsBaseUrl
         });


### PR DESCRIPTION
The mozaik.config variable holds 'env' which is used by the HTML template to determine if it should use the minified version of mozaik.js. Previously in use was the mozaik.serverConfig which consists of
```
serverConfig = {
    host: config.host,
    port: config.port
}
```