### PR TITLE
Add config option for WebSockets port

### DIFF
--- a/src/browser/stores/ApiStore.js
+++ b/src/browser/stores/ApiStore.js
@@ -16,7 +16,12 @@ var ApiStore = Reflux.createStore({
             proto = 'wss';
         }
 
-        ws = new WebSocket(`${ proto }://${ window.document.location.host }`);
+        var port = 80;
+        if (config.wsPort > 0) {
+          port = config.wsPort;
+        }
+
+        ws = new WebSocket(`${ proto }://${ window.document.location.host }:${ port }`);
         ws.onmessage = event => {
             ApiStore.trigger(JSON.parse(event.data));
         };


### PR DESCRIPTION
At 18F, we were recently playing around with deploying the mozaik-demo on https://cloud.gov. Our hosting environment requires that WebSockets be served on a port other than 80. This PR adds an option to configure that port.