### PR TITLE
Use configured host

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -35,7 +35,7 @@ module.exports = function (mozaik, app) {
         res.send(_.omit(mozaik.config, 'api'));
     });
 
-    var server = app.listen(config.port, function () {
+    var server = app.listen(config.port, config.host, function () {
         mozaik.logger.info(chalk.yellow('Mozaïk server listening at http://' + config.host + ':' + config.port));
     });
 


### PR DESCRIPTION
Actually use the host configured in `config.host`

This change + the pull request #51 allowed me to deploy mozaik on Openshift.