### PR TITLE
Update watchify to prevent segment fault errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "swig": "^1.4.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
-    "watchify": "^2.4.0",
+    "watchify": "^3.7.0",
     "winston": "^0.9.0",
     "ws": "1.0.1"
   },


### PR DESCRIPTION
Older versions of chokidar (dependency of watchify) cause segment fault errors

f.x. https://github.com/paulmillr/chokidar/issues/219