### PR TITLE
Show more helpful error if required files missing

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -31,8 +31,8 @@ gulp.task('styles:dev', ['collect:styles'], function () {
             theme = mozaikThemePath;
         }
 
-        if (fs.existsSync(path.join(theme, '_vars.styl')) === false || fs.existsSync(path.join(theme, 'index.styl')) == false) {
-            return done(new Error(chalk.red('Please make sure your theme contains both \'_vars.styl\' and \'index.styl\' files (path: ' + theme + ')')));
+        if (fs.existsSync(path.join(theme, '_vars.styl')) === false || fs.existsSync(path.join(theme, 'index.styl')) === false) {
+            return reject(new Error(chalk.red('Please make sure your theme contains both \'_vars.styl\' and \'index.styl\' files (path: ' + theme + ')')));
         }
 
         gutil.log(chalk.green('Compiling stylus code using theme \'' + theme + '\''));


### PR DESCRIPTION
Replaces `ReferenceError: done is not defined` with the text of the error itself.