### PR TITLE
Add autoprefixer

### DIFF
--- a/browserlist
+++ b/browserlist
@@ -1,0 +1,4 @@
+# Supported Browsers by Mozaik
+
+Chrome > 27 # so flex rules receive a -webkit- prefix
+> 1%

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -46,10 +46,7 @@ gulp.task('styles:dev', ['collect:styles'], function () {
                     style.define('$theme', theme);
                 }
             }))
-            .pipe(autoprefixer({
-                browsers: ['Chrome > 27'],
-                cascade: false
-            }))
+            .pipe(autoprefixer({ cascade: false }))
             .pipe(gulp.dest(config.dest + 'css'))
         );
     });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,11 +1,12 @@
-var gulp    = require('gulp');
-var path    = require('path');
-var stylus  = require('gulp-stylus');
-var fs      = require('fs');
-var gutil   = require('gulp-util');
-var chalk   = require('chalk');
-var config  = require('../config');
-var Promise = require('bluebird');
+var gulp         = require('gulp');
+var path         = require('path');
+var stylus       = require('gulp-stylus');
+var fs           = require('fs');
+var gutil        = require('gulp-util');
+var chalk        = require('chalk');
+var config       = require('../config');
+var Promise      = require('bluebird');
+var autoprefixer = require('gulp-autoprefixer');
 
 
 gulp.task('styles', ['styles:dev']);
@@ -44,6 +45,10 @@ gulp.task('styles:dev', ['collect:styles'], function () {
                 use: function (style) {
                     style.define('$theme', theme);
                 }
+            }))
+            .pipe(autoprefixer({
+                browsers: ['Chrome > 27'],
+                cascade: false
             }))
             .pipe(gulp.dest(config.dest + 'css'))
         );

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react"
   ],
   "dependencies": {
+    "gulp-autoprefixer": "3.1.0",
     "bluebird": "3.3.5",
     "browserify": "13.0.0",
     "browserify-resolutions": "1.0.6",


### PR DESCRIPTION
This PR adds autoprefixer to the Gulp Build. 

# Why?

Samsung Smart TVs seem to require the -webkit- prefix to fully support flexbox.

At the same time this gives the dashboard a greater range of supported browsers with a minimum of code.