### PR TITLE
Compile using compact mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "compact": true,
   "presets": [
     "es2015",
     "react"

--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -33,7 +33,7 @@ function getBundler(isDev) {
             'bluebird',
             'moment'
         ])
-        .transform(babelify, { presets: ['es2015', 'react'] })
+        .transform(babelify, { compact: true, presets: ['es2015', 'react'] })
     ;
 }
 


### PR DESCRIPTION
https://blog.mariusschulz.com/2016/07/12/speeding-up-babel-transpilation-with-compact-mode

tl;dr: Babel's compact mode seems to speed up compilation time (although it doesn't seem like it has a too huge compact for Mozaik)