### PR TITLE
[WIP] Add the ability to set individual timers

### DIFF
--- a/src/browser/stores/DashboardStore.js
+++ b/src/browser/stores/DashboardStore.js
@@ -8,6 +8,7 @@ var _dashboards      = [];
 var _currentIndex    = 0;
 var _config          = null;
 var _timer           = null;
+var _currentDuration = 0;
 
 
 const DashboardStore = Reflux.createStore({
@@ -25,14 +26,23 @@ const DashboardStore = Reflux.createStore({
 
     start() {
         if (_config.rotationDuration && _dashboards.length > 1 && _timer === null) {
+            if (_dashboards[0].rotationDuration) {
+                _config.rotationCheckInterval = _config.rotationCheckInterval || 5000 // we check every 5seconds if we should rotate the dashboard
+                _config.rotationDuration = _config.rotationCheckInterval
+            }
+
             _timer = setInterval(() => {
-                this.nextDashboard();
+                _currentDuration += _config.rotationCheckInterval
+                if (_currentDuration >= _dashboards[_currentIndex].rotationDuration) {
+                    this.nextDashboard();
+                }
             }, _config.rotationDuration);
         }
     },
 
     previousDashboard() {
         _currentIndex--;
+        _currentDuration = 0;
         this.trigger(_currentIndex);
     },
 
@@ -42,7 +52,8 @@ const DashboardStore = Reflux.createStore({
         } else {
             _currentIndex = 0;
         }
-
+    
+        _currentDuration = 0;
         this.trigger(_currentIndex);
     },
 
@@ -53,6 +64,7 @@ const DashboardStore = Reflux.createStore({
 
         _dashboards   = dashboards;
         _currentIndex = 0;
+        _currentDuration = 0;
 
         this.start();
 


### PR DESCRIPTION
## Todo
- [ ] Tests
- [ ] Update demo repo
## Usage

In config.js, 
_Optional_: add after `rotationDuration` `rotationCheckInterval: 5000` (checks every 5s if it should switch to the next board)
_Required_: every dashboard object in the dashboard array needs to have `rotationDuration`, e.g. `rotationDuration: 10000` means that board will be shown for 10 seconds and will then rotate.
