### PR TITLE
Remove undefined variable key

### DIFF
--- a/src/browser/components/charts/Pie.js
+++ b/src/browser/components/charts/Pie.js
@@ -150,7 +150,7 @@ class Pie {
 
         this.paths.exit()
             .datum(function (d, i) {
-                return  Pie.findNeighborArc(i, prevData, newData, key) || d;
+                return Pie.findNeighborArc(i, prevData, newData) || d;
             })
             .transition()
             .duration(transitionDuration)


### PR DESCRIPTION
Key is not defined which leads to errors (the function only takes 3 arguments anyway)