### PR TITLE
Fix link to mozaik-ext-calendar

### DIFF
--- a/extensions/index.html
+++ b/extensions/index.html
@@ -138,7 +138,7 @@
                 
                     <div class="extension">
     <div class="extension_name">
-        <a href="https://github.com/SC5/mozaik-ext-analytics" class="extension_link" target="_blank">
+        <a href="https://github.com/SC5/mozaik-ext-calendar" class="extension_link" target="_blank">
             mozaik-ext-calendar
         </a>
         <a href="https://www.npmjs.com/package/mozaik-ext-calendar" target="_blank">


### PR DESCRIPTION
The link to the GitHub project of `mozaik-ext-calendar` was wrongly set to `https://github.com/SC5/mozaik-ext-analytics`