### PR TITLE
Fix undefined reported as error on fetch configuration

### DIFF
--- a/src/ui/actions/configurationActions.js
+++ b/src/ui/actions/configurationActions.js
@@ -30,7 +30,8 @@ export const fetchConfiguration = () => {
         return fetch('/config')
             .then(res => {
                 if (res.status !== 200) {
-                    return Promise.reject(`Unable to fetch configuration: ${res.statusText} (${res.status})`)
+                    return Promise.reject(new Error(
+                        `Unable to fetch configuration: ${res.statusText} (${res.status})`))
                 }
 
                 return res.json()


### PR DESCRIPTION
Error notification in `configurationActions.js` expects an `Error` (or equivalent) object:

```js
                dispatch(notifyError({
                    message: `An error occurred while fetching configuration: ${err.message}`,
                    ttl:     -1,
                }))
```

However, on failed fetch of `/config` `Promise` is rejected with a plain string resulting in `An error occurred while fetching configuration: undefined` notification. This PR fixes the issue.