### PR TITLE
Bug fix: WidgetStatusBadge should pick matching icon

### DIFF
--- a/packages/ui/src/components/widget/status/WidgetStatusBadge.js
+++ b/packages/ui/src/components/widget/status/WidgetStatusBadge.js
@@ -41,11 +41,15 @@ const iconMapping = [
 ]
 
 const getIcon = status => {
-    const icon = _.find(iconMapping, mapping => {
+    const matchedMapping = _.find(iconMapping, mapping => {
         return mapping.match.includes(status)
     })
 
-    return icon || QuestionIcon
+    if (matchedMapping) {
+        return matchedMapping.icon
+    } else {
+        return QuestionIcon
+    }
 }
 
 class WidgetStatusBadge extends Component {


### PR DESCRIPTION
The value returned by `getIcon` is expected to be a component (lines 68 and 98)