### PR TITLE
Feature: Support multiple endpoints with different config files and themes

### DIFF
--- a/packages/ui/src/actions/configurationActions.js
+++ b/packages/ui/src/actions/configurationActions.js
@@ -1,6 +1,7 @@
 import { connect } from './wsActions'
 import { setDashboards, play } from './dashboardsActions'
 import { notifySuccess, notifyError } from './notificationsActions'
+import { setTheme } from '../actions/themesActions'
 
 export const FETCH_CONFIGURATION = 'FETCH_CONFIGURATION'
 export const FETCH_CONFIGURATION_SUCCESS = 'FETCH_CONFIGURATION_SUCCESS'
@@ -20,14 +21,10 @@ export const fetchConfiguration = () => {
     return dispatch => {
         dispatch({ type: FETCH_CONFIGURATION })
 
-        return fetch('/config')
+        return fetch('config')
             .then(res => {
                 if (res.status !== 200) {
-                    return Promise.reject(
-                        new Error(
-                            `Unable to fetch configuration: ${res.statusText} (${res.status})`
-                        )
-                    )
+                    return Promise.reject(new Error(`Unable to fetch configuration: ${res.statusText} (${res.status})`))
                 }
 
                 return res.json()
@@ -42,6 +39,9 @@ export const fetchConfiguration = () => {
                     })
                 )
                 dispatch(setDashboards(configuration.dashboards))
+                if (configuration.theme) {
+                    dispatch(setTheme(configuration.theme))
+                }
                 dispatch(play())
             })
             .catch(err => {

--- a/packages/ui/src/components/dashboard/DashboardHeader.js
+++ b/packages/ui/src/components/dashboard/DashboardHeader.js
@@ -48,6 +48,7 @@ class DashboardHeader extends Component {
         previous: PropTypes.func.isRequired,
         next: PropTypes.func.isRequired,
         pause: PropTypes.func.isRequired,
+        theme: PropTypes.object.isRequired,
     }
 
     render() {

--- a/packages/ui/src/components/settings/ThemesSetting.js
+++ b/packages/ui/src/components/settings/ThemesSetting.js
@@ -12,6 +12,7 @@ class ThemeSetting extends Component {
         themes: PropTypes.object.isRequired,
         currentTheme: PropTypes.string.isRequired,
         setTheme: PropTypes.func.isRequired,
+        theme: PropTypes.object.isRequired,
     }
 
     shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
Allows a single Mozaik server to support multiple endpoints, each with their own config file specifying different dashboards and default theme.

This is designed to be backwards compatible with the existing API, i.e. you can still pass in a single config file as in [the demo server](https://github.com/plouc/mozaik-demo/blob/mozaik-2/server.js). Similarly, the `configure` method detects whether it's being passed an object specifying configurations for each path, or a singe config object for the root path.

## Usage

Update your [server.js](https://github.com/plouc/mozaik-demo/blob/mozaik-2/server.js) file to pass in an object instead of a single config file. The object keys define the URL paths and each object value is a separate config file for that endpoint:

```
require('dotenv').load({ silent: true })

const path = require('path')
const Mozaik = require('@mozaik/server')

let rootConfigFile = process.argv[2] || 'conf/config.yml'

let configFiles = {
    [Mozaik.rootPath]: path.join(__dirname, rootConfigFile),
    analytics: path.join(__dirname, 'conf/config-ga.yml'),
    github: path.join(__dirname, 'conf/config-github.yml'),
    'github/stats': path.join(__dirname, 'conf/config-github-stats.yml'),
    gitlab: path.join(__dirname, 'conf/config-gitlab.yml'),
    'gitlab/labels': path.join(__dirname, 'conf/config-gitlab-labels-charts.yml'),
    time: path.join(__dirname, 'conf/config-time.yml'),
    travis: path.join(__dirname, 'conf/config-travis.yml'),
}

Mozaik.configureFromFiles(configFiles)
    .then(() => {
        require('./src/register_apis')(Mozaik)
        Mozaik.start()
    })
    .catch(err => {
        console.error(err)
    })
```

Note that the webpack dev server and auto-reloading of config files both work only with the root endpoint. So, for development work, you should still specify the config file containing the dashboards that you're working on as a command-line parameter to `yarn start`.