### PR TITLE
Enhancement: Allow widgets to accept array data from APIs

### DIFF
--- a/packages/ui/src/components/widget/WidgetWrapper.js
+++ b/packages/ui/src/components/widget/WidgetWrapper.js
@@ -10,7 +10,8 @@ const ignoreProps = ['extension', 'widget', 'registry', 'apiData', 'apiError']
 
 class WidgetWrapper extends Component {
     static propTypes = {
-        apiData: PropTypes.object,
+        apiData: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+        apiError: PropTypes.object,
         extension: PropTypes.string.isRequired,
         widget: PropTypes.string.isRequired,
         subscriptionId: PropTypes.string,

--- a/packages/ui/src/reducers/apiReducer.js
+++ b/packages/ui/src/reducers/apiReducer.js
@@ -16,8 +16,6 @@ const defaultState = Map({
 })
 
 export default function configuration(state = defaultState, action) {
-    let subscriptions
-
     switch (action.type) {
         case API_SUBSCRIBE:
             if (state.get('subscriptions').has(action.subscription.id)) {


### PR DESCRIPTION
This is already supported by the API Reducer (and explicitly covered in its test). Just broadening the allowed PropTypes to avoid spurious warnings.