### PR TITLE
Added the path name to the end of the WebSocket URL

### DIFF
--- a/src/browser/stores/ApiStore.js
+++ b/src/browser/stores/ApiStore.js
@@ -51,6 +51,7 @@ const connectWS = (config, store) => {
     if (port && port !== '') {
         wsUrl = `${wsUrl}:${port}`;
     }
+    wsUrl = wsUrl + window.location.pathname          
 
     ws = new WebSocket(wsUrl);
 


### PR DESCRIPTION
…so that both Express and Socket calls can gain the same path insight, without jumping through potentially dangerous hoops