### PR TITLE
[2.x] Added the path name to the end of the WebSocket URL

### DIFF
--- a/packages/ui/src/lib/WSHelper.js
+++ b/packages/ui/src/lib/WSHelper.js
@@ -22,6 +22,7 @@ export const guessWSURL = (config = {}) => {
     if (port && port !== '') {
         wsUrl = `${wsUrl}:${port}`
     }
+    wsUrl = wsUrl + window.location.pathname
 
     return wsUrl
 }


### PR DESCRIPTION
…so that both Express and Socket calls can gain the same path insight, without jumping through potentially dangerous hoops