### PR TITLE
Ability to set the configuration to the bus instance

### DIFF
--- a/packages/server/src/bus.js
+++ b/packages/server/src/bus.js
@@ -33,7 +33,7 @@ class Bus {
     }
 
     setConfiguration(configuration = {}) {
-        this.configuration = Object.assign(this.configuration, DEFAULT_CONFIGURATION, configuration);
+        Object.assign(this.configuration, DEFAULT_CONFIGURATION, configuration);
     }
 
     /**

--- a/packages/server/src/bus.js
+++ b/packages/server/src/bus.js
@@ -8,10 +8,12 @@ const logger = require('./logger')
 const API_MODE_POLL = 'poll'
 const API_MODE_PUSH = 'push'
 
-const DEFAULT_POLL_INTERVAL = 15000
-
 const API_DATA_MESSAGE = 'api.data'
 const API_ERROR_MESSAGE = 'api.error'
+
+const DEFAULT_CONFIGURATION = {
+    pollInterval: 15000
+}
 
 /**
  * Bus class.
@@ -24,9 +26,14 @@ class Bus {
         this.apis = {}
         this.clients = {}
         this.subscriptions = {}
+        this.configuration = {}
 
         this.logger = options.logger || logger
-        this.pollInterval = options.pollInterval || DEFAULT_POLL_INTERVAL
+        this.setConfiguration()
+    }
+
+    setConfiguration(configuration = {}) {
+        this.configuration = Object.assign(this.configuration, DEFAULT_CONFIGURATION, configuration);
     }
 
     /**
@@ -262,7 +269,7 @@ class Bus {
 
             this.subscriptions[subscriptionId].timer = setInterval(() => {
                 this.processApiCall(subscriptionId, callFn, subscription.params)
-            }, this.pollInterval)
+            }, this.configuration.pollInterval)
         }
 
         // avoid adding a client for the same API call twice

--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -21,13 +21,16 @@ const bus = new Bus({
     logger,
 })
 
-exports.configure = _configuration => {
+const setConfiguration = _configuration => {
     configuration = _configuration
+    bus.setConfiguration(_configuration)
 }
+
+exports.configure = setConfiguration
 
 const loadConfig = configurationPath => {
     return loadYaml(configurationPath).then(_configuration => {
-        configuration = _configuration
+        setConfiguration(_configuration)
 
         return configuration
     })


### PR DESCRIPTION
The bus instance do not receives the YML data because it's created before loading the configuration file ([packages/server/src/index.js#L20](https://github.com/plouc/mozaik/blob/v2.x/packages/server/src/index.js#L20)).

I've added a `configuration` attribute to the bus instance to store all the info from the YMLs and then be allowed to override it when either `configure` or `loadConfig` is called.