### PR TITLE
fix: server broken tests

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -12,24 +12,29 @@
     "@mozaik/server": "^2.0.0-alpha.7",
     "@mozaik/themes": "^1.0.0-alpha.17",
     "@mozaik/ui": "^2.0.0-rc.2",
+    "http-proxy-middleware": "^0.20.0",
     "nivo": "^0.15.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0"
   },
   "devDependencies": {
-    "react-scripts": "1.1.4"
-  },
-  "proxy": {
-    "/socket": {
-      "target": "ws://localhost:5000",
-      "ws": true
-    },
-    "/config": {
-      "target": "http://localhost:5000"
-    }
+    "cross-env": "^7.0.0",
+    "react-scripts": "^3.3.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('dotenv').load({ silent: true })
+require('dotenv').config()
 
 const path = require('path')
 const server = require('@mozaik/server').default

--- a/demo/src/setupProxy.js
+++ b/demo/src/setupProxy.js
@@ -1,6 +1,6 @@
 const proxy = require('http-proxy-middleware')
 
 module.exports = function (app) {
-  app.use(proxy('/socket', { target: 'http://localhost:5003/', ws: true }))
-  app.use(proxy('/config', { target: 'http://localhost:5003/' }))
+  app.use(proxy('/socket', { target: 'http://localhost:5000/', ws: true }))
+  app.use(proxy('/config', { target: 'http://localhost:5000/' }))
 }

--- a/demo/src/setupProxy.js
+++ b/demo/src/setupProxy.js
@@ -1,0 +1,6 @@
+const proxy = require('http-proxy-middleware')
+
+module.exports = function (app) {
+  app.use(proxy('/socket', { target: 'http://localhost:5003/', ws: true }))
+  app.use(proxy('/config', { target: 'http://localhost:5003/' }))
+}

--- a/packages/server/test/bus.test.ts
+++ b/packages/server/test/bus.test.ts
@@ -1,4 +1,4 @@
-declare var jest, beforeAll, it, expect
+import 'jest'
 
 import chalk from 'chalk'
 import { Socket } from 'socket.io'

--- a/packages/server/test/bus_add_client.test.ts
+++ b/packages/server/test/bus_add_client.test.ts
@@ -1,4 +1,4 @@
-declare var jest, beforeAll, it, expect
+import 'jest'
 
 import chalk from 'chalk'
 import { Socket } from 'socket.io'

--- a/packages/server/test/bus_process_api_call.test.ts
+++ b/packages/server/test/bus_process_api_call.test.ts
@@ -1,4 +1,4 @@
-declare var jest, it, expect, beforeAll
+import 'jest'
 
 import chalk from 'chalk'
 import Bus from '../src/bus'
@@ -10,7 +10,7 @@ beforeAll(() => {
 
 it('should log api call', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     expect.assertions(2)
 
@@ -22,14 +22,14 @@ it('should log api call', () => {
 
 it('should support calling apis which return promises', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     const apiMock = jest.fn(() => Promise.resolve('test'))
     const apiParams = { param: 'param' }
 
     expect.assertions(3)
 
-    return bus.processApiCall('test_api.test_method', apiMock, apiParams).then(message => {
+    return bus.processApiCall('test_api.test_method', apiMock, apiParams).then((message: any) => {
         expect(apiMock).toHaveBeenCalled()
         expect(apiMock).toHaveBeenCalledWith(apiParams)
         expect(message).toEqual({
@@ -41,14 +41,14 @@ it('should support calling apis which return promises', () => {
 
 it('should support calling apis which does not return promises', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     const apiMock = jest.fn(() => 'test')
     const apiParams = { param: 'param' }
 
     expect.assertions(3)
 
-    return bus.processApiCall('test_api.test_method', apiMock, apiParams).then(message => {
+    return bus.processApiCall('test_api.test_method', apiMock, apiParams).then((message: any) => {
         expect(apiMock).toHaveBeenCalled()
         expect(apiMock).toHaveBeenCalledWith(apiParams)
         expect(message).toEqual({
@@ -60,7 +60,7 @@ it('should support calling apis which does not return promises', () => {
 
 it('should cache result', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     bus.subscriptions['test_api.test_method'] = { clients: [] }
 
@@ -79,7 +79,7 @@ it('should cache result', () => {
 
 it('should notify clients on success', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     const emitMock = jest.fn()
     bus.clients = {
@@ -104,7 +104,7 @@ it('should notify clients on success', () => {
 
 it('should not notify clients on error and log error', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     const emitMock = jest.fn()
     bus.clients = {

--- a/packages/server/test/bus_process_api_call.test.ts
+++ b/packages/server/test/bus_process_api_call.test.ts
@@ -14,10 +14,12 @@ it('should log api call', () => {
 
     expect.assertions(2)
 
-    return bus.processApiCall('test_api.test_method', () => {}).then(() => {
-        expect(logger.info).toHaveBeenCalled()
-        expect(logger.info).toHaveBeenCalledWith(`Calling 'test_api.test_method'`)
-    })
+    return bus
+        .processApiCall('test_api.test_method', () => {})
+        .then(() => {
+            expect(logger.info).toHaveBeenCalled()
+            expect(logger.info).toHaveBeenCalledWith(`Calling 'test_api.test_method'`)
+        })
 })
 
 it('should support calling apis which return promises', () => {
@@ -66,15 +68,17 @@ it('should cache result', () => {
 
     expect.assertions(3)
 
-    return bus.processApiCall('test_api.test_method', () => 'test').then(() => {
-        const subscriptions = bus.listSubscriptions()
-        expect(subscriptions['test_api.test_method']).not.toBeUndefined()
-        expect(subscriptions['test_api.test_method']).toHaveProperty('cached')
-        expect(subscriptions['test_api.test_method'].cached).toEqual({
-            id: 'test_api.test_method',
-            data: 'test',
+    return bus
+        .processApiCall('test_api.test_method', () => 'test')
+        .then(() => {
+            const subscriptions = bus.listSubscriptions()
+            expect(subscriptions['test_api.test_method']).not.toBeUndefined()
+            expect(subscriptions['test_api.test_method']).toHaveProperty('cached')
+            expect(subscriptions['test_api.test_method'].cached).toEqual({
+                id: 'test_api.test_method',
+                data: 'test',
+            })
         })
-    })
 })
 
 it('should notify clients on success', () => {
@@ -93,13 +97,15 @@ it('should notify clients on success', () => {
 
     expect.assertions(2)
 
-    return bus.processApiCall('test_api.test_method', () => 'test').then(() => {
-        expect(emitMock).toHaveBeenCalled()
-        expect(emitMock).toHaveBeenCalledWith('api.data', {
-            id: 'test_api.test_method',
-            data: 'test',
+    return bus
+        .processApiCall('test_api.test_method', () => 'test')
+        .then(() => {
+            expect(emitMock).toHaveBeenCalled()
+            expect(emitMock).toHaveBeenCalledWith('api.data', {
+                id: 'test_api.test_method',
+                data: 'test',
+            })
         })
-    })
 })
 
 it('should not notify clients on error and log error', () => {

--- a/packages/server/test/bus_register_api.test.ts
+++ b/packages/server/test/bus_register_api.test.ts
@@ -42,7 +42,7 @@ it(`should allow to set API mode to 'push'`, () => {
     const logger = loggerMock()
     const bus = new Bus({ logger })
 
-    bus.registerApi('test_api', () => { }, PollMode.Push)
+    bus.registerApi('test_api', () => {}, PollMode.Push)
 
     expect(bus.listApis()).toEqual(['test_api'])
     expect(logger.info).toHaveBeenCalled()
@@ -56,7 +56,7 @@ it('should throw if we pass an invalid API mode', () => {
     const expectedError = `API mode 'invalid' is not a valid mode, must be one of 'poll' or 'push'`
 
     expect(() => {
-        bus.registerApi('test_api', () => { }, 'invalid' as PollMode)
+        bus.registerApi('test_api', () => {}, 'invalid' as PollMode)
     }).toThrow(expectedError)
 
     expect(logger.error).toHaveBeenCalled()

--- a/packages/server/test/bus_register_api.test.ts
+++ b/packages/server/test/bus_register_api.test.ts
@@ -1,7 +1,7 @@
-declare var jest, it, expect, beforeAll
+import 'jest'
 
 import chalk from 'chalk'
-import Bus from '../src/bus'
+import Bus, { PollMode } from '../src/bus'
 import loggerMock from './logger'
 
 beforeAll(() => {
@@ -42,7 +42,7 @@ it(`should allow to set API mode to 'push'`, () => {
     const logger = loggerMock()
     const bus = new Bus({ logger })
 
-    bus.registerApi('test_api', () => {}, 'push')
+    bus.registerApi('test_api', () => { }, PollMode.Push)
 
     expect(bus.listApis()).toEqual(['test_api'])
     expect(logger.info).toHaveBeenCalled()
@@ -56,7 +56,7 @@ it('should throw if we pass an invalid API mode', () => {
     const expectedError = `API mode 'invalid' is not a valid mode, must be one of 'poll' or 'push'`
 
     expect(() => {
-        bus.registerApi('test_api', () => {}, 'invalid')
+        bus.registerApi('test_api', () => { }, 'invalid' as PollMode)
     }).toThrow(expectedError)
 
     expect(logger.error).toHaveBeenCalled()

--- a/packages/server/test/bus_remove_client.test.ts
+++ b/packages/server/test/bus_remove_client.test.ts
@@ -1,4 +1,4 @@
-declare var jest, it, expect, beforeAll
+import 'jest'
 
 import chalk from 'chalk'
 import { Socket } from 'socket.io'
@@ -31,7 +31,7 @@ it('should cleanup subscription and remove timer if no clients left', () => {
     bus.addClient({
         id: 'test_client',
         emit: jest.fn(),
-    } as Socket)
+    } as unknown as Socket)
     expect(bus.listClients()).toHaveProperty('test_client')
 
     bus.registerApi('test_api', () => ({
@@ -39,7 +39,7 @@ it('should cleanup subscription and remove timer if no clients left', () => {
     }))
     expect(bus.listApis()).toEqual(['test_api'])
 
-    bus.subscribe('test_client', { id: 'test_api.test' } as Subscription)
+    bus.subscribe('test_client', { id: 'test_api.test', clients: [] })
 
     const subscriptions = bus.listSubscriptions()
     expect(subscriptions['test_api.test'].timer).not.toBeUndefined()

--- a/packages/server/test/bus_remove_client.test.ts
+++ b/packages/server/test/bus_remove_client.test.ts
@@ -28,10 +28,10 @@ it('should cleanup subscription and remove timer if no clients left', () => {
     const logger = loggerMock()
     const bus = new Bus({ logger })
 
-    bus.addClient({
+    bus.addClient(({
         id: 'test_client',
         emit: jest.fn(),
-    } as unknown as Socket)
+    } as unknown) as Socket)
     expect(bus.listClients()).toHaveProperty('test_client')
 
     bus.registerApi('test_api', () => ({

--- a/packages/server/test/bus_subscribe.test.ts
+++ b/packages/server/test/bus_subscribe.test.ts
@@ -8,8 +8,8 @@ import { Socket } from 'socket.io'
 jest.useFakeTimers()
 
 beforeEach(() => {
-    chalk.enabled = false;
-    (setInterval as any).mockClear()
+    chalk.enabled = false
+    ;(setInterval as any).mockClear()
 })
 
 it('should log an error if there is no existing client having given id', () => {
@@ -100,7 +100,7 @@ it(`should immediately call the api if there's no matching subscription`, () => 
     const logger = loggerMock()
     const bus = new Bus({ logger })
     const apiMock = { fetch: jest.fn() }
-    const clientMock = { id: 'test_client', emit: jest.fn() } as unknown as Socket
+    const clientMock = ({ id: 'test_client', emit: jest.fn() } as unknown) as Socket
 
     bus.registerApi('test_api', () => apiMock)
     bus.addClient(clientMock)
@@ -119,7 +119,7 @@ it(`should create a timer if there's no matching subscription`, () => {
             }),
         })),
     }
-    const clientMock = { id: 'test_client', emit: jest.fn() } as unknown as Socket
+    const clientMock = ({ id: 'test_client', emit: jest.fn() } as unknown) as Socket
     const logger = loggerMock()
     const bus = new Bus({ logger })
 
@@ -151,7 +151,7 @@ it(`should create a producer if there's no matching subscription and API mode is
     const bus = new Bus({ logger })
 
     const pushMock = jest.fn()
-    const clientMock = { id: 'test_client', emit: jest.fn() } as unknown as Socket
+    const clientMock = ({ id: 'test_client', emit: jest.fn() } as unknown) as Socket
 
     bus.registerApi('test_api', () => ({ push: pushMock }), PollMode.Push)
     bus.addClient(clientMock)
@@ -171,8 +171,8 @@ it('should not add the same client id twice to the subscription client list', ()
     const logger = loggerMock()
     const bus = new Bus({ logger })
 
-    bus.registerApi('test_api', () => ({ push: () => { } }), PollMode.Push)
-    bus.addClient({ id: 'test_client', emit() {} } as unknown as Socket)
+    bus.registerApi('test_api', () => ({ push: () => {} }), PollMode.Push)
+    bus.addClient(({ id: 'test_client', emit() {} } as unknown) as Socket)
     bus.subscribe('test_client', { id: 'test_api.push', clients: [] })
 
     let subscriptions = bus.listSubscriptions()

--- a/packages/server/test/bus_unsubscribe.test.ts
+++ b/packages/server/test/bus_unsubscribe.test.ts
@@ -1,4 +1,4 @@
-declare var beforeAll, it, expect
+import 'jest'
 
 import chalk from 'chalk'
 import { Socket } from 'socket.io'
@@ -23,7 +23,7 @@ it('should warn if the client does not exist', () => {
 
 it('should warn if the subscription does not exist', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     bus.clients = { test_client: {} as Socket }
     bus.unsubscribe('test_client', 'invalid')
@@ -36,7 +36,7 @@ it('should warn if the subscription does not exist', () => {
 
 it('should remove client from subscription', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     bus.clients = { test_client: {} as Socket }
     bus.subscriptions = {
@@ -55,7 +55,7 @@ it('should remove client from subscription', () => {
 
 it('should remove subscription if no more client left', () => {
     const logger = loggerMock()
-    const bus = new Bus({ logger })
+    const bus: any = new Bus({ logger })
 
     bus.clients = { test_client: {} as Socket }
     bus.subscriptions = {

--- a/packages/server/test/load_yaml.test.ts
+++ b/packages/server/test/load_yaml.test.ts
@@ -6,7 +6,9 @@ it('should reject when file does not exist', () => {
     expect.assertions(1)
 
     return loadYaml('noent.yml').catch((err: any) =>
-        expect(err.message).toEqual(`ENOENT: no such file or directory, open '${path.resolve("noent.yml")}'`)
+        expect(err.message).toEqual(
+            `ENOENT: no such file or directory, open '${path.resolve('noent.yml')}'`
+        )
     )
 })
 

--- a/packages/server/test/load_yaml.test.ts
+++ b/packages/server/test/load_yaml.test.ts
@@ -1,20 +1,19 @@
-declare var jest, it, expect
-
 import * as path from 'path'
 import loadYaml from '../src/load_yaml'
+import 'jest'
 
 it('should reject when file does not exist', () => {
     expect.assertions(1)
 
-    return loadYaml('noent.yml').catch(err =>
-        expect(err.message).toEqual(`ENOENT: no such file or directory, open 'noent.yml'`)
+    return loadYaml('noent.yml').catch((err: any) =>
+        expect(err.message).toEqual(`ENOENT: no such file or directory, open '${path.resolve("noent.yml")}'`)
     )
 })
 
 it('should reject when file is not a valid yaml', () => {
     expect.assertions(1)
 
-    return loadYaml(path.join(__dirname, 'fixtures', 'config', 'invalid.yml')).catch(err =>
+    return loadYaml(path.join(__dirname, 'fixtures', 'config', 'invalid.yml')).catch((err: any) =>
         expect(err.message).toContain(
             `end of the stream or a document separator is expected at line 2, column 2`
         )
@@ -24,7 +23,7 @@ it('should reject when file is not a valid yaml', () => {
 it('should return parsed yaml', () => {
     expect.assertions(1)
 
-    return loadYaml(path.join(__dirname, 'fixtures', 'config', 'valid.yml')).then(data => {
+    return loadYaml(path.join(__dirname, 'fixtures', 'config', 'valid.yml')).then((data: any) => {
         expect(data).toEqual(`I'm an valid yaml file for testing purpose`)
     })
 })

--- a/packages/server/test/logger.ts
+++ b/packages/server/test/logger.ts
@@ -1,4 +1,4 @@
-declare var jest
+import 'jest'
 
 import { LeveledLogMethod } from 'winston'
 


### PR DESCRIPTION
Fix unit tests on the server package broken due to wrong typings.

You will find a trick by setting to `any` the type of `Bus` to make available a private membre of the class. 
Another weird trick: `{ id: 'test_client', emit: jest.fn() } as unknown as Socket` to cast the object to a Socket type.

The whole server package has unit test working.